### PR TITLE
Move tensorflow models to own hosting

### DIFF
--- a/data/demo/manifest.json
+++ b/data/demo/manifest.json
@@ -1,6 +1,6 @@
 {"models":[
   {"url":"http://reverbcvai2.eastus.cloudapp.azure.com","name":"CustomVision.ai (hierarchical)"},
   {"url":"http://reverbcvai1.eastus.cloudapp.azure.com","name":"CustomVision.ai (one model)"},
-  {"url":"http://reverbcvserver.eastus.cloudapp.azure.com:8000","name":"Inception"},
-  {"url":"http://reverbcvserver.eastus.cloudapp.azure.com:8001","name":"Mobilenet"}
+  {"url":"http://52.170.80.164","name":"Inception"},
+  {"url":"http://52.170.84.31","name":"Mobilenet"}
 ]}


### PR DESCRIPTION
These are now hosted in Azure Container Instances via the following
commands:

```sh
az container create \
  --resource-group reverb-hackfest \
  --name reverbinception \
  --image cwolff/reverbinception \
  --ip-address public \
  --cpu 2 \
  --memory 2

az container create \
  --resource-group reverb-hackfest \
  --name reverbmobilenet \
  --image cwolff/reverbmobilenet \
  --ip-address public \
  --cpu 2 \
  --memory 2
```